### PR TITLE
feat: add timestamp to export filenames, cache cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,5 +88,8 @@ dist/
 .env
 
 # Exported user data
-user-data.csv
-user-data.json
+user-data*.csv
+user-data*.json
+
+# Cookie cache
+cookie-cache.json

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
     "debug": "^3.0.1",
+    "fecha": "^3.0.2",
     "filesize": "^3.5.10",
     "form-urlencoded": "^3.0.0",
+    "keyv": "^3.1.0",
+    "keyv-file": "^0.1.11",
     "node-fetch": "^2.3.0",
     "progress-stream": "^2.0.0",
     "set-cookie-parser": "^2.3.5"
@@ -29,8 +32,10 @@
     "@types/clean-webpack-plugin": "^0.1.2",
     "@types/debug": "^4.1.1",
     "@types/dotenv-webpack": "^1.7.0",
+    "@types/fecha": "^2.3.1",
     "@types/filesize": "^4.0.1",
     "@types/form-urlencoded": "^2.0.0",
+    "@types/keyv": "^3.1.0",
     "@types/node-fetch": "^2.1.6",
     "@types/webpack": "^4.4.24",
     "@types/webpack-node-externals": "^1.6.3",

--- a/src/download.ts
+++ b/src/download.ts
@@ -4,6 +4,7 @@ import filesize from 'filesize';
 import progressStream from 'progress-stream';
 import { streamCompletion } from './util/stream';
 import { logger } from './util/logger';
+import fecha from 'fecha';
 
 const log = logger('epcal:download');
 
@@ -24,9 +25,18 @@ export const exportData = async (sessionCookie: string): Promise<void> => {
     throw new Error(`download failed: unexpected status code ${res.status}`);
   }
 
-  log(`connection established (${res.status}), downloading data export`);
+  const filename = `user-data-${fecha.format(
+    new Date(),
+    'YYYY-MM-DD--HH-mm-ss',
+  )}.csv`;
 
-  const file = fs.createWriteStream('user-data.csv');
+  log(
+    `connection established (${
+      res.status
+    }), downloading data export to ${filename}`,
+  );
+
+  const file = fs.createWriteStream(filename);
 
   const progress = progressStream({
     length: res.size,

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ const main = async (): Promise<void> => {
     );
   }
 
-  log('no session cookie, logging in');
+  log('authenticating');
   const sessionCookie = await authenticate(user as User);
   log('session cookie retrieved');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,6 +75,13 @@
   dependencies:
     "@types/webpack" "*"
 
+"@types/fecha@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/fecha/-/fecha-2.3.1.tgz#2ee937c0a2b760e165835d62385bb382226fc901"
+  integrity sha512-2PKrYmgQlrgJtQekwXQMkp1nMqDYnEVFxdFTiU5LzpWS87XYufw29TSOqaQ5GXP9R+4U5e0CdiSL8+DCDkyZNQ==
+  dependencies:
+    fecha "*"
+
 "@types/filesize@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/filesize/-/filesize-4.0.1.tgz#6ddde9183d80e7e8261641d7db46ab1ffd20bdcb"
@@ -84,6 +91,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/form-urlencoded/-/form-urlencoded-2.0.0.tgz#c2261384b701b48ed36acb76914b93bc35c2057c"
   integrity sha512-YSOtk4tKFNUTlh+e8T4TBEDVVT2E1C9gKoF0+7ArcM1YZqQ8L7lUr4DxJpCS0jY6xm7GmATev46neF3rUfwuKA==
+
+"@types/keyv@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.0.tgz#1961f73b3bf1084c044f79a070b45a5bfa6578b9"
+  integrity sha512-OxT2IEeRdwvoUyp8n1v1hTIFzATb3NQYN8OHv/XbXRHiF2DXwKyzoI4UUaQgwZkRflLaSgyttat+RfWgsKIMIQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/node-fetch@^2.1.6":
   version "2.1.6"
@@ -1057,7 +1071,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1:
+debug@^4.0.1, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -1519,6 +1533,11 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fecha@*, fecha@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-3.0.2.tgz#fb3adb02762ab6dd27f7d5419f2f6c21a4229cd7"
+  integrity sha512-oJK6YbKtmz1uvuDsUHOmo9X2HKmYAcRWtzW2yrCzOJRUfyGUEu/8cDymBdedgEnkdJiTpNyPogWqfTuYffU4yA==
+
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -1639,6 +1658,15 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fs-extra@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -1781,7 +1809,7 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -2240,6 +2268,11 @@ js-yaml@^3.12.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+  integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -2261,6 +2294,29 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+keyv-file@^0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/keyv-file/-/keyv-file-0.1.11.tgz#be22d3346c1aead610015519c52e04ba4c055386"
+  integrity sha512-EpsY1NnEsOww/3q1HupC6NMFolfHKlFGql8rDt+n2fS6KGEFNWPHElBlW7aQ841UWCBXcsQOMEsfpgWZ7Wnl4w==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^4.0.1"
+    tslib "^1.9.3"
+
+keyv@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
+  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
+  dependencies:
+    json-buffer "3.0.0"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -4002,7 +4058,7 @@ ts-node@^8.0.2:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -4059,6 +4115,11 @@ unique-slug@^2.0.0:
   integrity sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==
   dependencies:
     imurmurhash "^0.1.4"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds two features that should get the project into a minimally usable state. Timestamps on export filenames ensure that exports are not overwritten, and cookie caching reduces unnecessary overhead and strain on episodecalendar's servers. For a really basic setup, you could have the project run as cron job now.